### PR TITLE
using SafeLoader to load config

### DIFF
--- a/src/main/python/yadoma/main.py
+++ b/src/main/python/yadoma/main.py
@@ -118,7 +118,8 @@ def main():
     config_paths = arguments['<config>']
     for config_path in config_paths:
         base_dir = os.path.dirname(config_path)
-        loaded_config = yaml.load(open(config_path).read())
+        loaded_config = yaml.load(open(config_path).read(),
+                                  Loader=yaml.SafeLoader)
         verbose('loaded config:')
         verbose(loaded_config)
         for program, program_config in loaded_config.items():


### PR DESCRIPTION
Newer versions of PyYaml don't like a simple `yaml.load` and demand receiving a `Loader` instance. My understanding is that this would result in an error in the future. This is getting rid of the `DeprecationWarning` for now and probably the error in the future. I figure `SafeLoader` is a safe default, feel free to change to something else. `FullLoader` would probably be fine too (just local files), but I don't think it's needed anyway.